### PR TITLE
Cleanup stray print statements, make tests pass

### DIFF
--- a/cranserver/lib/package.py
+++ b/cranserver/lib/package.py
@@ -43,9 +43,9 @@ class Package:
 
     def description(self):
         if not self._description:
-            self._description = self._extract_desc(self._untar())
+            self._description = Description(self._extract_desc(self._untar()))
             self._fileobj.seek(0)
-        return Description(self._description)
+        return self._description
 
     @property
     def fileobj(self):
@@ -53,14 +53,17 @@ class Package:
 
     @property
     def name(self):
-        return self._attr_from_description('Package', self.description())
+        return self.description().name
 
     @property
     def version(self):
-        return self._attr_from_description('Version', self.description())
+        return self.description().version
 
     @property
     def id(self):
+        return self.key()
+
+    def key(self):
         return self.name + '_' + self.version
 
     @property

--- a/cranserver/lib/storage.py
+++ b/cranserver/lib/storage.py
@@ -1,59 +1,26 @@
-from abc import ABC, abstractmethod
 import os
 import shutil
 import time
 
 
-class Storage(ABC):
-
-    def __init__(self):
-        "docstring"
-        pass
-
-    @abstractmethod
-    def ls(self):
-        "List all packages available."
-        pass
-
-    @abstractmethod
-    def fetch(self, pkg):
-        "Fetch package from storage backend."
-        pass
-
-    @abstractmethod
-    def push(self, pkg):
-        "Save package to storage backend."
-        pass
-
-
-class Storage:
+class Storage(dict):
     """
+    Storage is just a special dict.
+
     :key:   should be a string key
     :value: should be a stream of bytes
     """
-    _PACKAGES_KEY = 'src/contrib/PACKAGES'
-
-    def __getitem__(self, key):
-        pass
-
-    def __setitem__(self, key, value):
-        pass
-
-    def __iter__(self):
-        pass
-
-    def __contains__(self, other):
-        pass
 
     def PACKAGES(self):
-        return self[self._PACKAGES_KEY]
+        raise NotImplementedError
 
 
-class InMemoryStorage(dict, Storage):
+class InMemoryStorage(Storage):
     pass
 
 
 class FileStorage(Storage):
+
 
     def __init__(self, directory):
         self.directory = directory
@@ -75,45 +42,4 @@ class FileStorage(Storage):
             shutil.copyfileobj(fobj, f, length=16384)
 
     def PACKAGES(self):
-        fp = os.path.join(self.directory, self._PACKAGES_KEY)
-        try:
-            with open(fp, 'r') as f:
-                return f.read()
-        except FileNotFoundError:
-            return None
-
-    def _pkg_tupl(self, fp):
-        return fp.split('/')[-1].replace('.tar.gz', '').split('_')
-
-    def _fp_to_pkg_dict(self, fp):
-        _name, _version = self._pkg_tupl(fp)
-        return {
-            'key': fp,
-            'name': _name,
-            'version': _version,
-            'date': None,
-            'artifact_link': None
-        }
-
-    def ls(self):
-        files = os.listdir(os.path.join(self.directory, 'src/contrib/'))
-        return [f for f in files if 'PACKAGES' not in f]
-
-    def _set(self, pkg_id, fobj):
-        fp = os.path.join(self.directory, pkg_id + '.tar.gz')
-        with open(fp, 'wb') as f:
-            shutil.copyfileobj(fobj, f, length=16384)
-
-    def fetch(self, pkg_id):
-        fp = os.path.join(self.directory, pkg_id + '.tar.gz')
-        try:
-            with open(fp, 'rb') as f:
-                return f.read()
-        except FileNotFoundError:
-            return None
-
-    def push(self, pkg):
-        return self._set(pkg.id, pkg.fileobj)
-
-    def packages(self):
-        return [self._fp_to_pkg_dict(fp) for fp in self.ls()]
+        return self.get('PACKAGES')

--- a/cranserver/server.py
+++ b/cranserver/server.py
@@ -123,7 +123,6 @@ def packages_file_rest(*args, **kwargs):
 @app.route('/src/<path:path>.tar.gz', methods=['GET'])
 def packages(path):
     pkg_name = os.path.basename(path)
-    import sys; print(pkg_name, file=sys.stderr)
     pkg = registry.fetch(pkg_name)
     return send_file(BytesIO(pkg.fileobj), mimetype='application/octet-stream')
 

--- a/cranserver/server.py
+++ b/cranserver/server.py
@@ -21,10 +21,6 @@ from lib.registry import DuplicatePkgException
 CONFLICT_CODE = 409
 LOCK_CODE = 500
 
-SRC_PACKAGES_FILE_LOC = 'src/contrib/PACKAGES'
-LOCK_FILE_LOC = 'lockfile.lockfile'
-LOCK_TIMEOUT = 5
-
 STORAGE_BACKEND = os.getenv('STORAGE_BACKEND', 'filesystem')
 
 if STORAGE_BACKEND == 'filesystem':

--- a/cranserver/server.py
+++ b/cranserver/server.py
@@ -25,7 +25,6 @@ SRC_PACKAGES_FILE_LOC = 'src/contrib/PACKAGES'
 LOCK_FILE_LOC = 'lockfile.lockfile'
 LOCK_TIMEOUT = 5
 
-DEFAULT_BUCKET = os.getenv('DEFAULT_BUCKET')
 STORAGE_BACKEND = os.getenv('STORAGE_BACKEND', 'filesystem')
 
 if STORAGE_BACKEND == 'filesystem':
@@ -34,13 +33,13 @@ if STORAGE_BACKEND == 'filesystem':
     # TODO Make ./src/contrib directory if it doesn't exist
     src_contrib_storage = FileStorage(f'{fsloc}/src/contrib')
 elif STORAGE_BACKEND == 'aws' or STORAGE_BACKEND == 's3':
+    DEFAULT_BUCKET = os.getenv('DEFAULT_BUCKET')
     from contrib.s3 import S3Storage
     src_contrib_storage = S3Storage()
 else:
     raise Exception(f'Storage backend "{STORAGE_BACKEND}" not supported')
 
 src_contrib = Registry(src_contrib_storage)
-
 
 app = Flask(__name__, template_folder='templates', static_folder='static')
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     install_requires=[
         'boto3',
         'botocore',
-        'fasteners',
         'flask',
         'python-debian'
     ],

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -18,11 +18,6 @@ port='8081'
 
 url="http://$host:$port"
 
-cd $src_base
-
-# First install the app
-python setup.py install
-
 # set environment variables for flask
 export FLASK_APP="$src_base/cranserver/server.py"
 export PYTHONPATH="$src_base/cranserver/"

--- a/tests/test_lib_package.py
+++ b/tests/test_lib_package.py
@@ -37,7 +37,7 @@ class TestPackage:
 
     def test_description(self, pkg):
         desc = pkg.description()
-        assert desc == PKG_DESCRIPTION
+        assert desc.dump() == PKG_DESCRIPTION
 
     def test_version(self, pkg):
         assert pkg.version == PKG_VERSION

--- a/tests/test_lib_storage.py
+++ b/tests/test_lib_storage.py
@@ -1,19 +1,16 @@
 import pytest
-from cranserver.lib.package import Package
-from cranserver.lib.storage import FileStorage
+from cranserver.lib.storage import *
+from cranserver.lib.package import *
 
 @pytest.fixture
 def fs():
     return FileStorage('.')
 
 
-class TestFileStorage:
+class TestInMemoryStorage:
 
-    def test_push_and_fetch(self, fs, pkg):
-        fs.push(pkg)
-        with fs.fetch('httr_1.3.1') as f:
-            pkg = Package.from_tarball(f)
-            assert pkg.name == 'httr'
-
-    def test_contains(self, fs, pkg):
-        assert pkg in fs
+    def test_set(self, pkg):
+        storage = InMemoryStorage()
+        key = '/src/contrib/httr_1.3.1.tar.gz'
+        storage[key] = pkg
+        assert key in storage


### PR DESCRIPTION
This PR does a bunch of cleanup to `server.py`. In particular, here I remove the locking loigc from the server, since I think it's up to the storage or registry backends to implement.