### PR TITLE
update dockerfile to fix quickstart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM continuumio/miniconda3
 MAINTAINER Troy de Freitas "troy.defreitas@uptake.com", Nick Paras "nick.paras@uptake.com"
 
-RUN apt-get update -y && apt-get install -y python3-pip
+RUN apt-get update -y
 
-RUN pip3 install flask boto3 gunicorn fasteners
+RUN pip install flask boto3 gunicorn python-debian
 
 RUN mkdir -p "/opt/cran/uploads" && \
     mkdir -p "/opt/cran/src/contrib/" && \


### PR DESCRIPTION
using pip3 was causing the call to gunicorn to use the wrong python (3.4)

error from before the change:
```
[2018-09-14 14:21:18 +0000] [7] [INFO] Starting gunicorn 19.9.0
[2018-09-14 14:21:18 +0000] [7] [INFO] Listening at: http://0.0.0.0:80 (7)
[2018-09-14 14:21:18 +0000] [7] [INFO] Using worker: sync
[2018-09-14 14:21:18 +0000] [10] [INFO] Booting worker with pid: 10
[2018-09-14 14:21:18 +0000] [10] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.4/dist-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/opt/cranserver/server.py", line 37
    raise Exception(f'Storage backend "{STORAGE_BACKEND}" not supported')
                                                                       ^
SyntaxError: invalid syntax
[2018-09-14 14:21:18 +0000] [10] [INFO] Worker exiting (pid: 10)
[2018-09-14 14:21:18 +0000] [7] [INFO] Shutting down: Master
[2018-09-14 14:21:18 +0000] [7] [INFO] Reason: Worker failed to boot.
```